### PR TITLE
Allow linked domains using .serviceEndpoint

### DIFF
--- a/resources/did-configuration/index.html
+++ b/resources/did-configuration/index.html
@@ -649,7 +649,7 @@
           <li>The object MUST contain a `type` property, and its value MUST be the string `"LinkedDomains"`.</li>
           <li>The object MUST contain an `origins` property, and its value MUST be an array of one or more 
             <a href="https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy">domain origins</a>,
-            or a single `endpoint` property conveying a domain prefixed by `https://`.</li>
+            or a single `serviceEndpoint` property conveying a domain prefixed by `https://`.</li>
         </ul>
       </p>
 

--- a/resources/did-configuration/index.html
+++ b/resources/did-configuration/index.html
@@ -648,7 +648,8 @@
           <li>The object MUST contain an `id` property, and its value MUST be a valid DID URL reference.</li>
           <li>The object MUST contain a `type` property, and its value MUST be the string `"LinkedDomains"`.</li>
           <li>The object MUST contain an `origins` property, and its value MUST be an array of one or more 
-            <a href="https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy">domain origins</a>.</li>
+            <a href="https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy">domain origins</a>,
+            or a single `endpoint` property conveying a domain prefixed by `https://`.</li>
         </ul>
       </p>
 


### PR DESCRIPTION
Not all DID methods provide a way to populate a `serviceEndpoint` object with arbitrary keys like `origins`. For compatibility, it's helpful to provide an approach to linked domains that looks just like a normal endpoint -- e.g.

```
"service": [{
  "id":"#linked-domain",
  "type":"LinkedDomains",
  "serviceEndpoint":"https://domain.example.com"
}]
```

This would be functionally equivalent to:
```
"service": [{
  "id":"#linked-domain",
  "type":"LinkedDomains",
  "origins":["domain.example.com"]
}]
```