### PR TITLE
Fix typo in documentation for .well-known/did-configuration.json

### DIFF
--- a/resources/did-configuration/index.html
+++ b/resources/did-configuration/index.html
@@ -572,8 +572,8 @@
 
         <li>
           If <a>Domain Linkage Credential</a> verification is successfull, a
-          <a>Verifier</a> SHOULD consider the entitry controlling the
-          <a>origin</a>and the <a>Controller</a> of the <a>DID</a> to be the
+          <a>Verifier</a> SHOULD consider the entity controlling the
+          <a>origin</a> and the <a>Controller</a> of the <a>DID</a> to be the
           same entity.
         </li>
       </ol>

--- a/resources/did-configuration/index.html
+++ b/resources/did-configuration/index.html
@@ -378,7 +378,7 @@
         >
       </h2>
       <p>
-        A Verifiable Credential represenrted as JSON-LD or JSON Web Token.
+        A Verifiable Credential represented as JSON-LD or JSON Web Token.
       </p>
 
       <p>


### PR DESCRIPTION
Addresses a couple of copy issues in the .well-known/did-configuration.json spec language.