### PR TITLE
Update terminology links to point to used VC DataModel Version 1.1 

### DIFF
--- a/resources/did-configuration/index.html
+++ b/resources/did-configuration/index.html
@@ -151,7 +151,7 @@
         <p>
           See the normative definition
           <a
-            href="https://www.w3.org/TR/vc-data-model/#dfn-issuers"
+            href="https://www.w3.org/TR/vc-data-model-1.1/#dfn-issuers"
             target="_blank"
             >here</a
           >, [[vc-data-model]].
@@ -165,7 +165,7 @@
         <p>
           See the normative definition
           <a
-            href="https://www.w3.org/TR/vc-data-model/#dfn-subjects"
+            href="https://www.w3.org/TR/vc-data-model-1.1/#dfn-subjects"
             target="_blank"
             >here</a
           >, [[vc-data-model]].
@@ -197,7 +197,7 @@
         <p>
           See the normative definition
           <a
-            href="https://www.w3.org/TR/vc-data-model/#dfn-verifier"
+            href="https://www.w3.org/TR/vc-data-model-1.1/#dfn-verifier"
             target="_blank"
             >here</a
           >, [[vc-data-model]].
@@ -213,7 +213,7 @@
         <p>
           See the normative definition
           <a
-            href="https://www.w3.org/TR/vc-data-model/#json-web-token"
+            href="https://www.w3.org/TR/vc-data-model-1.1/#json-web-token"
             target="_blank"
             >here</a
           >, [[vc-data-model]].
@@ -232,7 +232,7 @@
         <p>
           See the normative definition
           <a
-            href="https://www.w3.org/TR/vc-data-model/#linked-data-proofs"
+            href="https://www.w3.org/TR/vc-data-model-1.1/#linked-data-proofs"
             target="_blank"
             >here</a
           >, [[vc-data-model]].
@@ -390,7 +390,7 @@
       <p>
         In order to eliminate ambiguity between
         <a
-          href="https://www.w3.org/TR/vc-data-model/#proof-formats"
+          href="https://www.w3.org/TR/vc-data-model-1.1/#proof-formats"
           target="_blank"
           >proof-formats</a
         >, the following requirements must be observed.


### PR DESCRIPTION
Update Terminology links to point to used VC DataModel Version 1.1

Rational:
The DataModel in use for latest version of spec is VC-DataModel V1.1 not V2.0.

Chore: Create a new version of this spec based on VC-DataModel 2.0